### PR TITLE
skipLibCheck: true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": false,
     "baseUrl": "./src",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/compiler-options.html

Should make compiling and recompiling faster

Caveat:  

>Note that it is not safe to always compile with this flag on - your CI server or something should leave it off to make sure you don't break anything long-term. --[source](https://github.com/Microsoft/TypeScript/issues/13538)